### PR TITLE
AE-639 - parseNumber - Add support for u2212 character.

### DIFF
--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -20,6 +20,7 @@ export const parseNumber = R.compose(
     R.compose(Either.Right, txt => parseFloat(txt)),
     R.always(Either.Left(R.applyTo('parsing.invalid-number')))
   ),
+  R.replace(/\u2212/g, '-'),
   R.replace(/,/g, '.'),
   R.replace(/\s/g, '')
 );


### PR DESCRIPTION
Number parsing supports 002D and 2212 characters as a negative number sign.