### PR TITLE
AE-774 - fix empty et merge

### DIFF
--- a/src/components/Energiatodistus/empty.js
+++ b/src/components/Energiatodistus/empty.js
@@ -270,7 +270,7 @@ export const energiatodistus2013 = R.compose(
   ),
   R.assocPath(
     ['tulokset', 'kaytettavat-energiamuodot', 'muu'],
-    R.times(emptyMuuEnergiamuoto, 3)
+    R.times(emptyMuuEnergiamuoto, 1)
   ),
   R.assocPath(
     ['tulokset', 'uusiutuvat-omavaraisenergiat'],

--- a/src/components/Energiatodistus/energiatodistus-api.js
+++ b/src/components/Energiatodistus/energiatodistus-api.js
@@ -59,7 +59,6 @@ const assertVersion = et => {
 const mergeEmpty = deep.mergeRight(R.anyPass([Either.isEither, Maybe.isMaybe]));
 
 export const deserialize = R.compose(
-  R.tap(console.log),
   R.cond([
     [R.propEq('versio', 2018), mergeEmpty(empty.energiatodistus2018())],
     [R.propEq('versio', 2013), mergeEmpty(empty.energiatodistus2013())]

--- a/src/components/Energiatodistus/energiatodistus-api.js
+++ b/src/components/Energiatodistus/energiatodistus-api.js
@@ -59,9 +59,10 @@ const assertVersion = et => {
 const mergeEmpty = deep.mergeRight(R.anyPass([Either.isEither, Maybe.isMaybe]));
 
 export const deserialize = R.compose(
+  R.tap(console.log),
   R.cond([
-    [R.propEq('versio', 2018), mergeEmpty(empty.energiatodistus2018)],
-    [R.propEq('versio', 2013), mergeEmpty(empty.energiatodistus2013)]
+    [R.propEq('versio', 2018), mergeEmpty(empty.energiatodistus2018())],
+    [R.propEq('versio', 2013), mergeEmpty(empty.energiatodistus2013())]
   ]),
   evolveForVersion('deserializer'),
   R.tap(assertVersion),

--- a/src/utils/deep-objects_test.js
+++ b/src/utils/deep-objects_test.js
@@ -69,6 +69,7 @@ describe('Deep objects:', () => {
     it('Arrays', () => {
       assert.deepEqual(objects.mergeRight(R.F, [1], [2]), [2]);
       assert.deepEqual(objects.mergeRight(R.F, {a: [1, 2]}, {a: [2]}), {a: [2, 2]});
+      assert.deepEqual(objects.mergeRight(R.F, {a: [2, 2]}, {a: [1]}), {a: [1, 2]});
     });
 
     it('Mixed', () => {


### PR DESCRIPTION
empty et is used to provide default values if value is not provided from backend e.g. array values