### PR TITLE
AE-142 - copy energiatodistus - 

### DIFF
--- a/src/components/Energiatodistus/EnergiatodistusForm.svelte
+++ b/src/components/Energiatodistus/EnergiatodistusForm.svelte
@@ -280,7 +280,7 @@
         cancel={reset}
         {energiatodistus}
         {eTehokkuus}
-        {dirty}
+        dirty={dirty || R.isNil(energiatodistus.id)}
         {whoami}
         bind:inputLanguage />
     </div>

--- a/src/components/Energiatodistus/NewEnergiatodistus.svelte
+++ b/src/components/Energiatodistus/NewEnergiatodistus.svelte
@@ -38,6 +38,7 @@
     R.assoc('laskutettava-yritys-id', Maybe.None()),
     R.assoc('laskuriviviite', Maybe.None()),
     R.assoc('laatija-id', Maybe.None()),
+    R.dissoc('laatija-fullname'),
     R.assoc('kommentti', Maybe.None()),
     R.assoc('tila-id', ET.tila.draft),
     R.dissoc('id')

--- a/src/components/ToolBar/ToolBar.svelte
+++ b/src/components/ToolBar/ToolBar.svelte
@@ -1,9 +1,10 @@
 <script>
   import * as R from 'ramda';
 
-  import { replace } from 'svelte-spa-router';
+  import { replace, push } from 'svelte-spa-router';
   import * as Maybe from '@Utility/maybe-utils';
   import * as Future from '@Utility/future-utils';
+  import * as Kayttajat from '@Utility/kayttajat';
   import * as et from '@Component/Energiatodistus/energiatodistus-utils';
 
   import Confirm from '@Component/Confirm/Confirm';
@@ -213,13 +214,12 @@
       </span>
     </button>
   {/if}
-  {#if R.includes(Toolbar.module.copy, fields)}
-    {#if id.isSome()}
-      <button>
-        <span class="description">{$_('energiatodistus.toolbar.copy')}</span>
-        <span class="text-2xl font-icon">file_copy</span>
-      </button>
-    {/if}
+  {#if id.isSome() && Kayttajat.isLaatija(whoami)}
+    <button on:click={save(_ => push('/energiatodistus/' +
+          version + '/new?copy-from-id=' + id.some()))}>
+      <span class="description">{$_('energiatodistus.toolbar.copy')}</span>
+      <span class="text-2xl font-icon">file_copy</span>
+    </button>
   {/if}
   {#if R.includes(Toolbar.module.preview, fields)}
     {#each pdfUrls as pdfUrl}

--- a/src/language/fi.json
+++ b/src/language/fi.json
@@ -322,6 +322,10 @@
       "undodiscard": "Kumoa hylkäys",
       "delete": "Poista"
     },
+    "new": {
+      "draft": "Uusi luonnos",
+      "copy-from": "Uusi kopio todistuksesta"
+    },
     "id": "Energiatodistustunnus",
     "laatija-fullname": "Laatija",
     "laskuriviviite": "Projektiviite (näkyy laskurivillä)",

--- a/src/language/sv.json
+++ b/src/language/sv.json
@@ -320,6 +320,10 @@
       "undodiscard": "Kumoa hylkäys SV?",
       "delete": "Poista SV?"
     },
+    "new": {
+      "draft": "Uusi luonnos SV",
+      "copy-from": "Uusi kopio todistuksesta SV"
+    },
     "id": "Energicertifikatkod",
     "laatija-fullname": "Upprättare",
     "laskuriviviite": "Projektreferens (syns på fakturaraden)",


### PR DESCRIPTION
A new energiatodistus controller supports query param: copy-from-id. The data for a new et can be copied from an existing et.