### PR TITLE
Disable the comment field of a replaced ET

### DIFF
--- a/src/components/Energiatodistus/energiatodistus-utils.js
+++ b/src/components/Energiatodistus/energiatodistus-utils.js
@@ -350,6 +350,7 @@ export const isTilaInTilat = tilat =>
   R.compose(R.includes(R.__, tilat), R.prop('tila-id'));
 
 export const isDraft = R.propEq('tila-id', tila.draft);
+export const isReplaced = R.propEq('tila-id', tila.replaced);
 export const isSigned = R.propEq('tila-id', tila.signed);
 
 const kielisyydet = ['fi', 'sv', 'bilingual'];

--- a/src/components/Energiatodistus/paakayttajan-kommentti.svelte
+++ b/src/components/Energiatodistus/paakayttajan-kommentti.svelte
@@ -6,6 +6,7 @@
   import Textarea from '@Component/Textarea/Textarea';
   import * as inputs from './inputs';
   import * as formats from '@Utility/formats';
+  import * as EtUtils from './energiatodistus-utils';
 
   import HR from '@Component/HR/HR';
 
@@ -23,7 +24,7 @@
   <div class="w-full">
     <Textarea
       {id}
-      disabled={false}
+      disabled={EtUtils.isReplaced(model)}
       name={id}
       label={$_(['energiatodistus', ...path].join('.'))}
       lens={R.lensPath(path)}


### PR DESCRIPTION
This addresses AE-748 by disabling the operation that would fail.

It is not expected to be useful to have a valvoja comment an
energiatodistus that has been replaced.