### PR TITLE
AE-990 - fix iban validation error

### DIFF
--- a/src/components/Yritys/YritysForm.svelte
+++ b/src/components/Yritys/YritysForm.svelte
@@ -7,6 +7,7 @@
   import * as Either from '@Utility/either-utils';
   import * as Validation from '@Utility/validation';
   import * as Parsers from '@Utility/parsers';
+  import * as Formats from '@Utility/formats';
   import * as YritysUtils from './yritys-utils';
   import * as country from '@Component/Geo/country-utils';
 
@@ -240,7 +241,7 @@
         label={$_('yritys.verkkolaskuosoite')}
         bind:model={yritys}
         lens={R.lensProp('verkkolaskuosoite')}
-        format={Maybe.orSome('')}
+        format={Maybe.fold('', Formats.verkkolaskuosoite)}
         parse={formParsers.verkkolaskuosoite}
         validators={formSchema['verkkolaskuosoite']}
         i18n={$_} />

--- a/src/components/Yritys/yritys-utils.js
+++ b/src/components/Yritys/yritys-utils.js
@@ -52,7 +52,7 @@ export const formParsers = () => ({
   postinumero: R.trim,
   postitoimipaikka: R.trim,
   maa: R.trim,
-  verkkolaskuosoite: R.compose(Maybe.fromEmpty, R.trim),
+  verkkolaskuosoite: R.compose(Maybe.fromEmpty, R.trim, R.toUpper, R.replace(/\s/g, '')),
   verkkolaskuoperaattori: R.compose(Maybe.fromEmpty, R.trim)
 });
 

--- a/src/utils/formats.js
+++ b/src/utils/formats.js
@@ -1,6 +1,7 @@
 import * as dfns from 'date-fns';
 import * as R from 'ramda';
 import * as Maybe from '@Utility/maybe-utils';
+import * as Validation from '@Utility/validation';
 
 export const formatTimeInstant = time => dfns.format(time, 'd.M.yyyy H:mm:ss');
 export const formatDateInstant = date => dfns.format(date, 'd.M.yyyy');
@@ -29,3 +30,7 @@ export const inclusiveStartDate = Intl.DateTimeFormat('fi-FI',
 export const inclusiveEndDate = endTimeInstant =>
   Intl.DateTimeFormat('fi-FI', { timeZone: "UTC", dateStyle: 'medium' })
     .format(dfns.subHours(endTimeInstant, 10));
+
+export const iban = R.compose(R.join(' '), R.splitEvery(4));
+
+export const verkkolaskuosoite = R.when(Validation.isIBAN, iban);

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -181,12 +181,13 @@ export const isOVTTunnus = R.allPass([
   )
 ]);
 
-export const isIBAN = R.ifElse(
-  str => R.gte(R.length(str), 4),
+export const isIBAN = R.allPass([
+  R.compose(R.gt(R.__, 4), R.length),
+  R.test(/^[A-Z]{2}[A-Z0-9]*$/),
   R.compose(
     n => n.equals(1),
     n => n.mod(97),
-    BigInt,
+    R.tryCatch(BigInt, R.always(BigInt(0))),
     R.join(''),
     R.map(
       R.when(
@@ -195,10 +196,9 @@ export const isIBAN = R.ifElse(
       )
     ),
     R.toUpper,
-    R.converge(R.flip(R.concat), [R.take(4), R.drop(4)])
-  ),
-  R.always(false)
-);
+    R.converge(R.concat, [R.drop(4), R.take(4)])
+  )
+]);
 
 export const isTEOVTTunnus = R.allPass([
   R.compose(R.gte(R.__, 2), R.length),

--- a/src/utils/validation_test.js
+++ b/src/utils/validation_test.js
@@ -183,20 +183,27 @@ describe('Validation:', () => {
       assert.equal(validation.isOVTTunnus('000012345671'), false);
       assert.equal(validation.isOVTTunnus(null), false);
       assert.equal(validation.isOVTTunnus(''), false);
+      assert.equal(validation.isOVTTunnus('test@ara.fi'), false);
     });
   });
 
   describe('IBAN validation', () => {
     it('valid IBAN', () => {
-      assert.equal(validation.isIBAN('FI1410093000123458'), true);
-      assert.equal(validation.isIBAN('BR1500000000000010932840814P2'), true);
+      assert.isTrue(validation.isIBAN('FI1410093000123458'));
+      assert.isTrue(validation.isIBAN('BR1500000000000010932840814P2'));
+      assert.isTrue(validation.isIBAN('GB82WEST12345698765432'));
+      assert.isTrue(validation.isIBAN('BE71096123456769'));
+      assert.isTrue(validation.isIBAN('BR1500000000000010932840814P2'));
     });
 
     it('invalid IBAN', () => {
-      assert.equal(validation.isIBAN('FI1410093000123459'), false);
-      assert.equal(validation.isIBAN('FI14'), false);
-      assert.equal(validation.isIBAN(null), false);
-      assert.equal(validation.isIBAN(''), false);
+      assert.isFalse(validation.isIBAN('003712345671'));
+      assert.isFalse(validation.isIBAN('FI1410093000123459'));
+      assert.isFalse(validation.isIBAN('FI14'));
+      assert.isFalse(validation.isIBAN(null));
+      assert.isFalse(validation.isIBAN(''));
+      assert.isFalse(validation.isIBAN('test@ara.fi'));
+      assert.isFalse(validation.isIBAN('*?+2#/="'));
     });
   });
 


### PR DESCRIPTION
more strict validation: [A-Z]{2}[A-Z0-9], format for iban verkkolaskuosoite, parser for verkkolaskuosoite (remove ws, toUpper)