### PR TITLE
Ohjeiden korjauksia

### DIFF
--- a/src/components/Button/Button.svelte
+++ b/src/components/Button/Button.svelte
@@ -4,6 +4,7 @@
   export let style = 'primary';
   export let disabled = false;
   export let prefix = '';
+  export let title = '';
 </script>
 
 <style type="text/postcss">
@@ -36,6 +37,7 @@
   class:error={style === 'error'}
   class:disabled
   {disabled}
+  {title}
   on:click|stopPropagation>
   {text}
 </button>

--- a/src/components/Button/TextButton.svelte
+++ b/src/components/Button/TextButton.svelte
@@ -2,6 +2,8 @@
   export let text = '';
   export let icon = '';
   export let type = 'submit';
+  export let title = '';
+  export let disabled = false;
 </script>
 
 <style type="text/postcss">
@@ -9,7 +11,7 @@
     @apply flex justify-start items-center text-primary border-b-1 border-transparent font-semibold;
   }
 
-  button:hover {
+  button:hover:not(:disabled) {
     @apply border-primary;
   }
 
@@ -20,9 +22,13 @@
   button:focus {
     @apply outline-none;
   }
+
+  button:disabled {
+    @apply text-disabled cursor-not-allowed;
+  }
 </style>
 
-<button {type} on:click>
+<button {type} {title} {disabled} on:click>
   <span class="font-icon mr-1">{icon}</span>
   {text}
 </button>

--- a/src/components/Header/Header.svelte
+++ b/src/components/Header/Header.svelte
@@ -93,7 +93,7 @@
     <LanguageSelect />
   </div>
 
-  <div class="dropdowns flex space-x-8 items-center">
+  <div class="dropdowns flex space-x-16 items-center">
     {#if !R.isEmpty(ohjeNav)}
       <div class="flex flex-row justify-between">
         <div

--- a/src/components/ohje/editor.svelte
+++ b/src/components/ohje/editor.svelte
@@ -32,6 +32,8 @@
     overlay = true;
   };
   let sivu;
+  let sivut;
+  let isParent = false;
   $: load(params.id);
 
   const load = id => {
@@ -49,10 +51,19 @@
         overlay = false;
       },
       response => {
-        sivu = response;
+        sivu = response.sivu;
+        sivut = response.sivut;
+        isParent =
+          R.findIndex(
+            R.compose(Maybe.exists(R.equals(sivu['id'])), R.prop('parent-id'))
+          )(sivut) > -1;
+
         overlay = false;
       },
-      api.getSivu(id)
+      Future.parallelObject(2, {
+        sivu: api.getSivu(id),
+        sivut: api.getSivut
+      })
     );
   };
 
@@ -115,7 +126,10 @@
 <Overlay {overlay}>
   <div slot="content" class="w-full mt-3 flex space-x-4">
     <div class="w-2/6 max-w-xs">
-      <Navigation id={params.id} />
+      <Navigation
+        id={params.id}
+        sortDisabled={true}
+        sortButtonTitle={i18n('ohje.editor.sort-disabled')} />
     </div>
     <div class="w-4/6 flex-grow">
       {#if sivu}
@@ -189,6 +203,8 @@
                     on:click={() => {
                       confirm(deleteOhje);
                     }}
+                    disabled={isParent}
+                    title={isParent ? i18n('ohje.editor.delete-disabled') : ''}
                     text={i18n('ohje.editor.delete')}
                     style={'error'} />
                 </Confirm>

--- a/src/components/ohje/nav-link.svelte
+++ b/src/components/ohje/nav-link.svelte
@@ -156,11 +156,11 @@
       {/if}
     </div>
   </div>
-  {#if (!R.isEmpty(sivu.children) && childrenShown) || (draggable && isBeingTargeted && setDroppedAsChild)}
+  {#if (!R.isEmpty(sivu.children) && childrenShown && !isBeingDragged) || (draggable && isBeingTargeted && setDroppedAsChild && !isBeingDragged)}
     <div
       class="children pl-1 bg-secondary"
       transition:slide|local={{ duration: 100 }}>
-      {#if draggable && isBeingTargeted && setDroppedAsChild}
+      {#if draggable && isBeingTargeted && setDroppedAsChild && !isBeingDragged}
         <div
           class="destination flex w-full border-b items-center pointer-events-none">
           <span class="font-icon p-2"> subdirectory_arrow_right </span>
@@ -175,7 +175,7 @@
     </div>
   {/if}
 
-  {#if draggable && isBeingTargeted && !setDroppedAsChild}
+  {#if draggable && isBeingTargeted && !setDroppedAsChild && !isBeingDragged}
     <div
       class="destination flex w-full border-b items-center pointer-events-none">
       <span class="font-icon p-2"> east </span>

--- a/src/components/ohje/navigation.svelte
+++ b/src/components/ohje/navigation.svelte
@@ -16,6 +16,8 @@
   import Spinner from '@Component/Spinner/Spinner.svelte';
 
   export let id;
+  export let sortDisabled = false;
+  export let sortButtonTitle = '';
 
   const i18n = $_;
   let whoami = Maybe.None();
@@ -122,11 +124,14 @@
             {#if !sortMode}
               <TextButton
                 on:click={toggleSortMode}
+                disabled={sortDisabled}
+                title={sortButtonTitle}
                 icon="swap_vert"
                 text={i18n('ohje.navigation.sort')} />
             {:else}
               <TextButton
                 on:click={toggleSortMode}
+                title={sortButtonTitle}
                 icon="highlight_off"
                 text={i18n('ohje.navigation.end-sort')} />
             {/if}

--- a/src/language/fi.json
+++ b/src/language/fi.json
@@ -1344,6 +1344,8 @@
       "published": "Julkaistu",
       "submit": "Tallenna",
       "delete": "Poista",
+      "delete-disabled": "Poistaminen ei ole mahdollista jos sivulla on alisivuja",
+      "sort-disabled": "Sivujen järjestäminen on estetty muokkausnäkymässä",
       "cancel": "Peruuta",
       "success": "Sivun muokkaaminen onnistui",
       "error": "Sivun muokkaaminen epäonnistui",


### PR DESCRIPTION
AE-1144: Pääkäyttäjä muokkaa laatijaohjeiden sivuhierarkiaa (Poista nappi tulisi disabloida sivulta, jolla on alisiviuja)
AE-1095: Käyttäjä näkee ohjesivun (lisätä marginia ylävalikoiden Laatijan ohjeet  ja käyttäjämenu väliin)
AE-1097: Pääkäyttäjä voi poistaa ohjesivun (Poista nappi tulisi disabloida sivulta, jolla on alisiviuja)