### PR TITLE
AE-1297 Adjust the range of years in dropdown

### DIFF
--- a/src/components/Datepicker/litepicker.js
+++ b/src/components/Datepicker/litepicker.js
@@ -8,7 +8,12 @@ export const litepicker = (node, opts) => {
     format: 'D.M.YYYY',
     singleMode: true,
     lang: opts.lang,
-    dropdowns: { minYear: 1970, maxYear: null, months: true, years: true },
+    dropdowns: {
+      minYear: 2013,
+      maxYear: new Date().getFullYear() + 11,
+      months: true,
+      years: true
+    },
     onSelect: opts.update
   };
 


### PR DESCRIPTION
It is not expected that there will be ET searches where a year before
2013 would have much meaning.

Also with a 10-year validity period of Energiatodistus, it is expected
that users will not desire to set a search limit further in the future
than current year + 11 years.