### PR TITLE
AE-1431 Show a more precise message on bad ET id

### DIFF
--- a/src/language/fi.json
+++ b/src/language/fi.json
@@ -1233,6 +1233,7 @@
           "messages": {
             "update-success": "Energiatodistus liitoksen päivittäminen onnistui",
             "update-error": "Energiatodistus liitoksen päivittäminen epäonnistui",
+            "update-error-missing-et": "Energiatodistus ei ole olemassa",
             "validation-error": "Energiatodistus kenttä ei voi olla tyhjä ja arvon pitää olla numero"
           }
         },

--- a/src/pages/viesti/attach-energiatodistus-dialog.svelte
+++ b/src/pages/viesti/attach-energiatodistus-dialog.svelte
@@ -25,11 +25,15 @@
   const updateKetju = R.compose(
     Future.fork(
       response => {
-        const msg = i18n(
-          Maybe.orSome(
-            `${i18nRoot}.messages.update-error`,
-            Response.localizationKey(response)
-          )
+        const invalidEtId = (
+          response.body.constraint === 'viestiketju-energiatodistus-id-fkey' &&
+          response.body.type === 'foreign-key-violation');
+
+        const msg = i18n(invalidEtId ?
+                         `${i18nRoot}.messages.update-error-missing-et` :
+                         Maybe.orSome(
+                           `${i18nRoot}.messages.update-error`,
+                           Response.localizationKey(response))
         );
         buttonsDisabled = false;
         showAttachSpinner = false;


### PR DESCRIPTION
This relies on a [corresponding change in etp-core](https://github.com/solita/etp-core/pull/642), so that a bad ET id
does produce an internal server error response.

