### PR TITLE
AE-1579 Show the replacement link regardless of state

### DIFF
--- a/src/pages/valvonta-oikeellisuus/valvonta.svelte
+++ b/src/pages/valvonta-oikeellisuus/valvonta.svelte
@@ -180,9 +180,7 @@
           )}
         </div>
         <div>
-          {#each korvaavaEnergiatodistus
-            .toArray()
-            .filter(ETUtils.isSigned) as korvaavaEt}
+          {#each korvaavaEnergiatodistus.toArray() as korvaavaEt}
             <span>
               {Maybe.fold(
                 '',


### PR DESCRIPTION
The link may even point to an energiatodistus that is not accessible
by the pääkäyttäjä, but this is written with the assumption that we
are OK with that.