### PR TITLE
AE-1794 Add user interface to post toimenpide, bypassing Asha

### DIFF
--- a/src/language/fi.json
+++ b/src/language/fi.json
@@ -1859,7 +1859,8 @@
           "title": "Valvonnan lopetus",
           "info": "Tällä toimenpiteellä lopetaan virallinen valvontaprosessi ja suljetaan asia asiahallinnassa.",
           "description": "Kommentti",
-          "publish-button": "Lopeta"
+          "publish-button": "Lopeta",
+          "force-button": "Lopeta (vain ETP)"
         },
         "messages": {
           "not-found": "Toimenpidettä ei ole olemassa.",

--- a/src/language/sv.json
+++ b/src/language/sv.json
@@ -1869,7 +1869,8 @@
           "title": "Avslutande av kontroll",
           "info": "Med den här åtgärden avslutas den officiella kontrollprocessen och ärendet stängs i ärendehanteringen.",
           "description": "Kommentar",
-          "publish-button": "Avsluta"
+          "publish-button": "Avsluta",
+          "force-button": "Avsulta (endast ETP)"
         },
         "messages": {
           "not-found": "Det existerar ingen åtgärd.",

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -62,9 +62,10 @@
       publishPending = true;
       Future.fork(
         response => {
-          error = Maybe.Some(
-            i18n(Response.errorKey(i18nRoot, 'publish', response))
-          );
+          error = Maybe.Some({
+            ashaRequestDidFail: response?.body?.type === 'asha-request-failed',
+            message: i18n(Response.errorKey(i18nRoot, 'publish', response))
+          });
           publishPending = false;
         },
         _ => {
@@ -79,7 +80,10 @@
         publishFn(id, toimenpide)
       );
     } else {
-      error = Maybe.Some($_(`${i18nRoot}.messages.validation-error`));
+      error = Maybe.Some({
+        ashaRequestDidFail: false,
+        message: $_(`${i18nRoot}.messages.validation-error`)
+      });
       Validation.blurForm(form);
     }
   };
@@ -89,9 +93,10 @@
       previewPending = true;
       Future.fork(
         response => {
-          error = Maybe.Some(
-            i18n(Response.errorKey(i18nRoot, 'preview', response))
-          );
+          error = Maybe.Some({
+            message: i18n(Response.errorKey(i18nRoot, 'preview', response)),
+            ashaRequestDidFail: false
+          });
           previewPending = false;
         },
         response => {
@@ -102,7 +107,10 @@
         api
       );
     } else {
-      error = Maybe.Some($_(`${i18nRoot}.messages.validation-error`));
+      error = Maybe.Some({
+        message: $_(`${i18nRoot}.messages.validation-error`),
+        ashaRequestDidFail: false
+      });
       Validation.blurForm(form);
     }
   };
@@ -134,10 +142,10 @@
   <form class="content" bind:this={form}>
     <h1>{text(toimenpide, 'title')}</h1>
 
-    {#each error.toArray() as txt}
+    {#each error.toArray() as { message }}
       <div class="my-2 error">
         <span class="font-icon mr-2">error_outline</span>
-        <div>{txt}</div>
+        <div>{message}</div>
       </div>
     {/each}
 
@@ -219,7 +227,7 @@
           on:click={reload} />
       </div>
 
-      {#each error.toArray() as txt}
+      {#each error.toArray().filter(e => e.ashaRequestDidFail) as _}
         <div class="ml-auto mt-5">
           <Button
             text={text(toimenpide, 'force-button')}

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -57,7 +57,7 @@
     R.prop('template-id')
   )(toimenpide);
 
-  $: publish = toimenpide => {
+  $: publish = (publishFn, toimenpide) => {
     if (isValidForm(toimenpide)) {
       publishPending = true;
       Future.fork(
@@ -76,7 +76,7 @@
           publishPending = false;
           reload();
         },
-        ValvontaApi.postToimenpide(id, toimenpide)
+        publishFn(id, toimenpide)
       );
     } else {
       error = Maybe.Some($_(`${i18nRoot}.messages.validation-error`));
@@ -208,7 +208,7 @@
           text={text(toimenpide, 'publish-button')}
           showSpinner={publishPending}
           {disabled}
-          on:click={publish(toimenpide)} />
+          on:click={publish(ValvontaApi.postToimenpide, toimenpide)} />
       </div>
 
       <div class="mt-5">
@@ -218,6 +218,19 @@
           style={'secondary'}
           on:click={reload} />
       </div>
+
+      {#each error.toArray() as txt}
+        <div class="ml-auto mt-5">
+          <Button
+            text={text(toimenpide, 'force-button')}
+            showSpinner={publishPending}
+            {disabled}
+            on:click={publish(
+              ValvontaApi.postToimenpideBypassAsha,
+              toimenpide
+            )} />
+        </div>
+      {/each}
     </div>
   </form>
 </dialog>

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -63,7 +63,9 @@
       Future.fork(
         response => {
           error = Maybe.Some({
-            ashaRequestDidFail: response?.body?.type === 'asha-request-failed',
+            mayBypassAsha:
+              Toimenpiteet.isCloseCase(toimenpide) &&
+              ValvontaApi.isAshaFailure(response),
             message: i18n(Response.errorKey(i18nRoot, 'publish', response))
           });
           publishPending = false;
@@ -81,7 +83,7 @@
       );
     } else {
       error = Maybe.Some({
-        ashaRequestDidFail: false,
+        mayBypassAsha: false,
         message: $_(`${i18nRoot}.messages.validation-error`)
       });
       Validation.blurForm(form);
@@ -95,7 +97,7 @@
         response => {
           error = Maybe.Some({
             message: i18n(Response.errorKey(i18nRoot, 'preview', response)),
-            ashaRequestDidFail: false
+            mayBypassAsha: false
           });
           previewPending = false;
         },
@@ -109,7 +111,7 @@
     } else {
       error = Maybe.Some({
         message: $_(`${i18nRoot}.messages.validation-error`),
-        ashaRequestDidFail: false
+        mayBypassAsha: false
       });
       Validation.blurForm(form);
     }
@@ -227,7 +229,7 @@
           on:click={reload} />
       </div>
 
-      {#each error.toArray().filter(e => e.ashaRequestDidFail) as _}
+      {#each error.toArray().filter(e => e.mayBypassAsha) as _}
         <div class="ml-auto mt-5">
           <Button
             text={text(toimenpide, 'force-button')}

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -57,7 +57,7 @@
     R.prop('template-id')
   )(toimenpide);
 
-  $: publish = (publishFn, toimenpide) => {
+  $: publish = toimenpide => {
     if (isValidForm(toimenpide)) {
       publishPending = true;
       Future.fork(
@@ -77,7 +77,7 @@
           publishPending = false;
           reload();
         },
-        publishFn(id, toimenpide)
+        ValvontaApi.postToimenpide(id, toimenpide)
       );
     } else {
       error = Maybe.Some({
@@ -216,7 +216,7 @@
           text={text(toimenpide, 'publish-button')}
           showSpinner={publishPending}
           {disabled}
-          on:click={publish(ValvontaApi.postToimenpide, toimenpide)} />
+          on:click={publish({ 'bypass-asha': false, ...toimenpide })} />
       </div>
 
       <div class="mt-5">
@@ -233,10 +233,7 @@
             text={text(toimenpide, 'force-button')}
             showSpinner={publishPending}
             {disabled}
-            on:click={publish(
-              ValvontaApi.postToimenpideBypassAsha,
-              toimenpide
-            )} />
+            on:click={publish({ 'bypass-asha': true, ...toimenpide })} />
         </div>
       {/each}
     </div>

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -229,7 +229,7 @@
           on:click={reload} />
       </div>
 
-      {#each error.toArray().filter(e => e.mayBypassAsha) as _}
+      {#if error.exists(e => e.mayBypassAsha)}
         <div class="ml-auto mt-5">
           <Button
             text={text(toimenpide, 'force-button')}
@@ -237,7 +237,7 @@
             {disabled}
             on:click={publish({ 'bypass-asha': true, ...toimenpide })} />
         </div>
-      {/each}
+      {/if}
     </div>
   </form>
 </dialog>

--- a/src/pages/valvonta-kaytto/toimenpiteet.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet.js
@@ -28,6 +28,7 @@ export const isType = R.propEq('type-id');
 const isDeadlineType = R.includes(R.__, [1, 2, 3, 4]);
 export const hasDeadline = R.propSatisfies(isDeadlineType, 'type-id');
 
+export const isCloseCase = isType(type.closed);
 export const isAuditCase = R.complement(isType(type.closed));
 export const isAuditCaseToimenpideType = R.propSatisfies(
   R.includes(R.__, [1, 2, 3, 4, 5]),

--- a/src/pages/valvonta-kaytto/valvonta-api.js
+++ b/src/pages/valvonta-kaytto/valvonta-api.js
@@ -12,6 +12,9 @@ import * as Toimenpiteet from './toimenpiteet';
 
 import * as EtApi from '@Pages/energiatodistus/energiatodistus-api';
 
+export const isAshaFailure = response =>
+  response?.body?.type === 'asha-request-failed';
+
 export const url = {
   valvonnat: 'api/private/valvonta/kaytto',
   valvonta: id => `${url.valvonnat}/${id}`,

--- a/src/pages/valvonta-kaytto/valvonta-api.js
+++ b/src/pages/valvonta-kaytto/valvonta-api.js
@@ -20,8 +20,6 @@ export const url = {
   yritykset: kohdeId => `${url.valvonta(kohdeId)}/yritykset`,
   yritys: (id, kohdeId) => `${url.yritykset(kohdeId)}/${id}`,
   toimenpiteet: id => `${url.valvonta(id)}/toimenpiteet`,
-  toimenpiteetBypassAsha: id =>
-    `${url.valvonta(id)}/toimenpiteet/bypassing-asha`,
   previewHenkilo: (id, henkiloId) =>
     `${url.valvonta(id)}/toimenpiteet/henkilot/${henkiloId}/preview`,
   previewYritys: (id, yritysId) =>
@@ -213,7 +211,13 @@ const serializeToimenpide = R.compose(
       dfns.formatISO(date, { representation: 'date' })
     )
   }),
-  R.pick(['type-id', 'deadline-date', 'description', 'template-id'])
+  R.pick([
+    'type-id',
+    'deadline-date',
+    'description',
+    'template-id',
+    'bypass-asha'
+  ])
 );
 
 export const toimenpiteet = R.compose(
@@ -241,16 +245,6 @@ export const postToimenpide = R.curry((id, toimenpide) =>
   R.compose(
     Fetch.responseAsJson,
     Future.encaseP(Fetch.fetchWithMethod(fetch, 'post', url.toimenpiteet(id))),
-    serializeToimenpide
-  )(toimenpide)
-);
-
-export const postToimenpideBypassAsha = R.curry((id, toimenpide) =>
-  R.compose(
-    Fetch.responseAsJson,
-    Future.encaseP(
-      Fetch.fetchWithMethod(fetch, 'post', url.toimenpiteetBypassAsha(id))
-    ),
     serializeToimenpide
   )(toimenpide)
 );

--- a/src/pages/valvonta-kaytto/valvonta-api.js
+++ b/src/pages/valvonta-kaytto/valvonta-api.js
@@ -20,6 +20,8 @@ export const url = {
   yritykset: kohdeId => `${url.valvonta(kohdeId)}/yritykset`,
   yritys: (id, kohdeId) => `${url.yritykset(kohdeId)}/${id}`,
   toimenpiteet: id => `${url.valvonta(id)}/toimenpiteet`,
+  toimenpiteetBypassAsha: id =>
+    `${url.valvonta(id)}/toimenpiteet/bypassing-asha`,
   previewHenkilo: (id, henkiloId) =>
     `${url.valvonta(id)}/toimenpiteet/henkilot/${henkiloId}/preview`,
   previewYritys: (id, yritysId) =>
@@ -239,6 +241,16 @@ export const postToimenpide = R.curry((id, toimenpide) =>
   R.compose(
     Fetch.responseAsJson,
     Future.encaseP(Fetch.fetchWithMethod(fetch, 'post', url.toimenpiteet(id))),
+    serializeToimenpide
+  )(toimenpide)
+);
+
+export const postToimenpideBypassAsha = R.curry((id, toimenpide) =>
+  R.compose(
+    Fetch.responseAsJson,
+    Future.encaseP(
+      Fetch.fetchWithMethod(fetch, 'post', url.toimenpiteetBypassAsha(id))
+    ),
     serializeToimenpide
   )(toimenpide)
 );


### PR DESCRIPTION
Note - this revision is not yet aware that the functionality is available only in the closed toimenpide. Likely it would be better if backend communicated to the user interface when this kind of option is available.