### PR TITLE
AE-1815 Add api-key as an attribute of kayttaja

### DIFF
--- a/src/pages/kayttaja/kayttaja-api.js
+++ b/src/pages/kayttaja/kayttaja-api.js
@@ -13,13 +13,16 @@ const parseValidISODate = R.compose(
   Maybe.fromNull
 );
 
-export const deserialize = R.evolve({
-  login: parseValidISODate,
-  verifytime: parseValidISODate,
-  cognitoid: Maybe.fromNull,
-  henkilotunnus: Maybe.fromNull,
-  virtu: Maybe.fromNull
-});
+export const deserialize = R.compose(
+  R.assoc('api-key', Maybe.None()),
+  R.evolve({
+    login: parseValidISODate,
+    verifytime: parseValidISODate,
+    cognitoid: Maybe.fromNull,
+    henkilotunnus: Maybe.fromNull,
+    virtu: Maybe.fromNull
+  })
+);
 
 export const deserializeHistory = R.evolve({
   cognitoid: Maybe.fromNull,
@@ -89,7 +92,8 @@ export const getLaatijaById = R.curry((fetch, id) =>
 export const serialize = R.compose(
   R.evolve({
     henkilotunnus: Maybe.orSome(null),
-    virtu: Maybe.orSome(null)
+    virtu: Maybe.orSome(null),
+    'api-key': Maybe.orSome(null)
   }),
   R.omit(['id', 'login', 'cognitoid', 'verifytime'])
 );

--- a/src/pages/kayttaja/kayttaja-api.js
+++ b/src/pages/kayttaja/kayttaja-api.js
@@ -35,19 +35,16 @@ export const deserializeHistory = R.evolve({
   modifytime: R.compose(Either.right, Parsers.parseISODate)
 });
 
-export const deserializeLaatija = R.compose(
-  R.assoc('api-key', Maybe.None()),
-  R.evolve({
-    'vastaanottajan-tarkenne': Maybe.fromNull,
-    maa: Either.Right,
-    toimintaalue: Maybe.fromNull,
-    wwwosoite: Maybe.fromNull,
+export const deserializeLaatija = R.evolve({
+  'vastaanottajan-tarkenne': Maybe.fromNull,
+  maa: Either.Right,
+  toimintaalue: Maybe.fromNull,
+  wwwosoite: Maybe.fromNull,
 
-    // we assume that these dates are always valid from backend
-    toteamispaivamaara: R.compose(Either.right, Parsers.parseISODate),
-    'voimassaolo-paattymisaika': R.compose(Either.right, Parsers.parseISODate)
-  })
-);
+  // we assume that these dates are always valid from backend
+  toteamispaivamaara: R.compose(Either.right, Parsers.parseISODate),
+  'voimassaolo-paattymisaika': R.compose(Either.right, Parsers.parseISODate)
+});
 
 export const url = {
   all: 'api/private/kayttajat',

--- a/src/pages/kayttaja/new-kayttaja.svelte
+++ b/src/pages/kayttaja/new-kayttaja.svelte
@@ -29,7 +29,8 @@
     email: '',
     puhelin: '',
     virtu: Maybe.None(),
-    henkilotunnus: Maybe.None()
+    henkilotunnus: Maybe.None(),
+    'api-key': Maybe.None()
   };
 
   let kayttaja = emptyKayttaja;

--- a/src/pages/kayttaja/schema.js
+++ b/src/pages/kayttaja/schema.js
@@ -19,7 +19,8 @@ export const Kayttaja = {
   sukunimi: Validation.RequiredString(2, 200),
   email: [...Validation.RequiredString(2, 200), Validation.emailValidator],
   puhelin: Validation.RequiredString(2, 200),
-  virtu: [Validation.liftValidator(VirtuIDValidator)]
+  virtu: [Validation.liftValidator(VirtuIDValidator)],
+  'api-key': [Validation.liftValidator(Validation.apiPasswordValidator)]
 };
 
 export const virtuSchema = kayttaja =>


### PR DESCRIPTION
With a corresponding change in etp-core, all kayttaja objects, not just laatijas may have an api key hash.

api-key is added so that an empty value is set up on initialization and deserialization so that it gets sent to the backend which expects it to be there. api-key is not shown in the user interface at this point.