### PR TITLE
AE-1824 Trim out trailing /32 from ip address

### DIFF
--- a/src/pages/kayttaja/kayttaja-api.js
+++ b/src/pages/kayttaja/kayttaja-api.js
@@ -89,6 +89,10 @@ export const getLaatijaById = R.curry((fetch, id) =>
 );
 
 const deserializeKayttajaAineisto = R.evolve({
+  'ip-address': R.when(
+    addr => addr.endsWith('/32'),
+    addr => addr.substring(0, addr.length - 3)
+  ),
   'valid-until': Parsers.optionalParser(Parsers.parseISODate)
 });
 


### PR DESCRIPTION
The underlying format is a CIDR prefix, but backend assumes a /32 on input if the prefix length is not specified. At the moment, we do not intend to present other than single-address limits to users.