### PR TITLE
Add option to search valvonta by last used template

### DIFF
--- a/src/components/Select/Select2.stories.js
+++ b/src/components/Select/Select2.stories.js
@@ -1,0 +1,43 @@
+import * as R from 'ramda';
+import Select2 from './Select2';
+import * as Maybe from '@Utility/maybe-utils';
+import { _ } from '@Language/i18n';
+import { get } from 'svelte/store';
+
+export default { title: 'Select2' };
+
+export const withItems = () => ({
+  Component: Select2,
+  props: {
+    items: R.map(Maybe.Some, [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]),
+    model: { selected: Maybe.None() },
+    lens: R.lensProp('selected'),
+    format: Maybe.fold(get(_)('validation.no-selection'), R.identity)
+  }
+});
+
+export const withSelected = () => ({
+  Component: Select2,
+  props: {
+    items: [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+    model: { selected: 1 },
+    lens: R.lensProp('selected'),
+    format: R.identity
+  }
+});
+
+export const withObjects = () => ({
+  Component: Select2,
+  props: {
+    items: R.map(Maybe.Some, [
+      { id: 1, label: 'yksi' },
+      { id: 2, label: 'kaksi' },
+      { id: 3, label: 'kolme' },
+      { id: 4, label: 'neljä' },
+      { id: 5, label: 'viisi' }
+    ]),
+    model: { selected: Maybe.None() },
+    lens: R.lensProp('selected'),
+    format: Maybe.fold(get(_)('validation.no-selection'), R.prop('label'))
+  }
+});

--- a/src/components/Select/Select2.svelte
+++ b/src/components/Select/Select2.svelte
@@ -54,6 +54,7 @@
       modelValue
   );
 
+  let showDropdown;
   $: showDropdown = Maybe.isSome(active);
 
   let selectableItems = items;

--- a/src/pages/kayttaja/aineistoasiakas-form.svelte
+++ b/src/pages/kayttaja/aineistoasiakas-form.svelte
@@ -16,7 +16,7 @@
   import Button from '@Component/Button/Button';
   import Input from '@Component/Input/Input';
   import Checkbox from '@Component/Checkbox/Checkbox.svelte';
-  import Select from '@Component/Select/select2';
+  import Select from '@Component/Select/Select2';
   import Datepicker from '@Component/Input/Datepicker';
   import * as Parsers from '@Utility/parsers';
 

--- a/src/pages/valvonta-oikeellisuus/valvonnat.svelte
+++ b/src/pages/valvonta-oikeellisuus/valvonnat.svelte
@@ -37,7 +37,7 @@
   import Address from '@Pages/energiatodistus/address';
   import Checkbox from '@Component/Checkbox/Checkbox';
   import Select from '@Component/Select/Select';
-  import Select2 from '@Component/Select/select2';
+  import Select2 from '@Component/Select/Select2.svelte';
   import Link from '@Component/Link/Link.svelte';
   import Input from '@Component/Input/Input';
   import RakennuksenNimi from '@Pages/energiatodistus/RakennuksenNimi';

--- a/src/pages/valvonta-oikeellisuus/valvonnat.svelte
+++ b/src/pages/valvonta-oikeellisuus/valvonnat.svelte
@@ -37,7 +37,7 @@
   import Address from '@Pages/energiatodistus/address';
   import Checkbox from '@Component/Checkbox/Checkbox';
   import Select from '@Component/Select/Select';
-  import Select2 from '@Component/Select/Select2.svelte';
+  import Select2 from '@Component/Select/Select2';
   import Link from '@Component/Link/Link.svelte';
   import Input from '@Component/Input/Input';
   import RakennuksenNimi from '@Pages/energiatodistus/RakennuksenNimi';

--- a/src/pages/viesti/viestit.svelte
+++ b/src/pages/viesti/viestit.svelte
@@ -26,7 +26,7 @@
   import Pagination from '@Component/Pagination/Pagination';
   import Checkbox from '@Component/Checkbox/Checkbox';
   import Select from '@Component/Select/Select';
-  import Select2 from '@Component/Select/select2';
+  import Select2 from '@Component/Select/Select2';
   import Input from '@Component/Input/Input';
 
   const i18n = $_;

--- a/src/pages/yritys/yritys-form.svelte
+++ b/src/pages/yritys/yritys-form.svelte
@@ -14,7 +14,7 @@
 
   import Autocomplete from '@Component/Autocomplete/Autocomplete';
   import Select from '@Component/Select/Select';
-  import Select2 from '@Component/Select/select2';
+  import Select2 from '@Component/Select/Select2';
   import H1 from '@Component/H/H1';
   import HR from '@Component/HR/HR';
   import Input from '@Component/Input/Input';


### PR DESCRIPTION
Used Select2 because it's supposedly the better way to do select nowadays.

Changed layout to use grid and gap instead of w- and margin, to actually fit items on one row on large displays. w- doesn't take margins into account, so 1/2 + 1/4 + 1/4 width items don't fit on one row.

Added stories for Select2.