### PR TITLE
AE-1942: Fix localization when browser asks for English page

### DIFF
--- a/src/language/i18n.js
+++ b/src/language/i18n.js
@@ -9,6 +9,7 @@ import {
 
 import fi from './fi.json';
 import sv from './sv.json';
+import { shortLocale } from '@Language/locale-utils';
 
 const setupI18n = () => {
   addMessages('fi-FI', fi);
@@ -16,9 +17,15 @@ const setupI18n = () => {
   addMessages('sv-FI', sv);
   addMessages('sv', sv);
 
+  const safeNavigatorLocale = ['fi', 'sv'].includes(
+    shortLocale(getLocaleFromNavigator())
+  )
+    ? getLocaleFromNavigator()
+    : 'fi';
+
   init({
     fallbackLocale: 'fi-FI',
-    initialLocale: localStorage.getItem('locale') || getLocaleFromNavigator()
+    initialLocale: localStorage.getItem('locale') || safeNavigatorLocale
   });
 };
 


### PR DESCRIPTION
Aineistoasiakas page used svelte localization store directly, bypassing fallback locale. When the browser asks for English page, that's stored into the store and loading aineistoasiakas-page fails because of undefined value.

Fixed by setting Finnish as the default value for locale store when navigator locale is non-supported.