### PR TITLE
Fix accessibility issues

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,7 +42,7 @@
 
 <style type="text/postcss">
   .appcontainer {
-    @apply w-full flex flex-col flex-grow justify-between min-h-screen;
+    @apply w-full flex flex-col flex-grow justify-between min-h-screen bg-ara-2021-light-gray-background;
   }
 
   .headercontainer,
@@ -52,10 +52,6 @@
 
   .headercontainer {
     @apply bg-secondary;
-  }
-
-  .footercontainer {
-    @apply bg-background;
   }
 </style>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -42,7 +42,7 @@
 
 <style type="text/postcss">
   .appcontainer {
-    @apply w-full flex flex-col flex-grow justify-between min-h-screen bg-ara-2021-light-gray-background;
+    @apply w-full flex flex-col flex-grow justify-between min-h-screen bg-light;
   }
 
   .headercontainer,
@@ -52,6 +52,10 @@
 
   .headercontainer {
     @apply bg-secondary;
+  }
+
+  .footercontainer {
+    @apply bg-ara-2021-light-gray-background;
   }
 </style>
 

--- a/src/components/Link/Link.svelte
+++ b/src/components/Link/Link.svelte
@@ -7,6 +7,7 @@
   export let icon = Maybe.None();
   export let disabled = false;
   export let bold = false;
+  export let additionalClasses = '';
 </script>
 
 <style type="text/postcss">
@@ -29,6 +30,6 @@
     <span class="font-icon mr-1">{i}</span>
   {/each}
   {#if text}
-    <span>{text}</span>
+    <span class={additionalClasses}>{text}</span>
   {/if}
 </a>

--- a/src/pages/energiatodistus/ToolBar/toolbar.svelte
+++ b/src/pages/energiatodistus/ToolBar/toolbar.svelte
@@ -229,7 +229,10 @@
           <div
             class="languageselect"
             class:bg-primary={R.equals(selectedLanguage, language)}
-            class:bg-disabled={!R.equals(selectedLanguage, language)}>
+            class:bg-ara-2021-basic-gray={!R.equals(
+              selectedLanguage,
+              language
+            )}>
             {language}
           </div>
         {/each}

--- a/src/pages/footer/Footer.svelte
+++ b/src/pages/footer/Footer.svelte
@@ -8,7 +8,7 @@
 
 <footer class="flex flex-col w-full text-sm">
   <div class="flex flex-col md:flex-row justify-between p-8">
-    <div class="flex flex-col text-primary mr-4">
+    <div class="flex flex-col mr-4 text-ara-2021-green-small-text">
       <span class="uppercase font-bold text-secondary">
         {$_('footer.contact-info')}
       </span>
@@ -21,12 +21,17 @@
         <div class="flex flex-col">
           <span class="font-bold"> {$_('footer.phone')}: </span>
           <div>
-            <Link bold={true} href="tel:0295250800" text={'029 525 0800'} />
+            <Link
+              bold={true}
+              additionalClasses="text-ara-2021-green-small-text"
+              href="tel:0295250800"
+              text={'029 525 0800'} />
           </div>
           <span class="font-bold mt-2"> {$_('footer.email')}: </span>
           <div>
             <Link
               bold={true}
+              additionalClasses="text-ara-2021-green-small-text"
               href={'mailto:energiatodistus@ara.fi'}
               text={'energiatodistus@ara.fi'} />
           </div>
@@ -41,6 +46,7 @@
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'pdf/Dataskyddsbeskrivning_Energicertifikatregistret.pdf'}
             target={'_blank'}
             text={'Dataskyddsbeskrivning Energicertifikatregistret (pdf)'} />
@@ -48,6 +54,7 @@
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'pdf/Dataskyddsbeskrivning_Register_for_overvakningsuppgifter_om_energicertifikat.pdf'}
             target={'_blank'}
             text={'Dataskyddsbeskrivning Register för övervakningsuppgifter om energicertifikat (pdf)'} />
@@ -55,6 +62,7 @@
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'pdf/Dataskyddsbeskrivning_Register_for_upprattare_av_energiferticikat.pdf'}
             target={'_blank'}
             text={'Dataskyddsbeskrivning Register för upprättare av energiferticikat (pdf)'} />
@@ -63,12 +71,14 @@
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'#/saavutettavuusseloste'}
             text={$_('footer.accessibility-report')} />
         </div>
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'pdf/Tietosuojaseloste_Energiatodistusrekisteri.pdf'}
             target={'_blank'}
             text={'Tietosuojaseloste Energiatodistusrekisteri (pdf)'} />
@@ -76,6 +86,7 @@
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'pdf/Tietosuojaseloste_Energiatodistusten_laatijarekisteri.pdf'}
             target={'_blank'}
             text={'Tietosuojaseloste Energiatodistusten laatijarekisteri (pdf)'} />
@@ -83,6 +94,7 @@
         <div>
           <Link
             bold={true}
+            additionalClasses="text-ara-2021-green-small-text"
             href={'pdf/Tietosuojaseloste_Energiatodistusten_valvontatietorekisteri.pdf'}
             target={'_blank'}
             text={'Tietosuojaseloste Energiatodistusten valvontatietorekisteri (pdf)'} />

--- a/src/pages/laatija/history-table.svelte
+++ b/src/pages/laatija/history-table.svelte
@@ -34,7 +34,8 @@
       <th class="etp-table--th">{i18n(i18nRoot + '.toteaja')}</th>
       <th class="etp-table--th">{i18n(i18nRoot + '.toteamispaivamaara')}</th>
       <th class="etp-table--th">{i18n(i18nRoot + '.laskutuskieli')}</th>
-    </thead><tbody class="etp-table--tbody">
+    </thead>
+    <tbody class="etp-table--tbody">
       {#each history as h}
         <tr class="etp-table--tr etp-table--tr">
           <td class="etp-table--td">
@@ -78,36 +79,21 @@
           </td>
           <td class="etp-table--td">
             <div class="flex flex-col">
-              <span
-                class={h.julkinenosoite
-                  ? 'font-bold text-primary'
-                  : 'text-disabled'}>
-                {i18n(i18nRoot + '.osoite')}
-              </span>
-              <span
-                class={h.julkinenpostinumero
-                  ? 'font-bold text-primary'
-                  : 'text-disabled'}>
-                {i18n(i18nRoot + '.postinumero')}
-              </span>
-              <span
-                class={h.julkinenpuhelin
-                  ? 'font-bold text-primary'
-                  : 'text-disabled'}>
-                {i18n(i18nRoot + '.puhelin')}
-              </span>
-              <span
-                class={h.julkinenemail
-                  ? 'font-bold text-primary'
-                  : 'text-disabled'}>
-                {i18n(i18nRoot + '.email')}
-              </span>
-              <span
-                class={h.julkinenwwwosoite
-                  ? 'font-bold text-primary'
-                  : 'text-disabled'}>
-                {i18n(i18nRoot + '.www-osoite')}
-              </span>
+              {#if h.julkinenosoite}
+                <span>{i18n(i18nRoot + '.osoite')} </span>
+              {/if}
+              {#if h.julkinenpostinumero}
+                <span>{i18n(i18nRoot + '.postinumero')} </span>
+              {/if}
+              {#if h.julkinenpuhelin}
+                <span>{i18n(i18nRoot + '.puhelin')} </span>
+              {/if}
+              {#if h.julkinenemail}
+                <span>{i18n(i18nRoot + '.email')} </span>
+              {/if}
+              {#if h.julkinenwwwosoite}
+                <span>{i18n(i18nRoot + '.www-osoite')} </span>
+              {/if}
             </div>
           </td>
           <td class="etp-table--td">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,7 +23,14 @@ module.exports = {
       hr: 'rgba(52, 56, 65, 0.3)',
       transparent: 'rgba(0,0,0,0)',
       tableborder: 'rgba(167,167,167,0.3)',
-      beige: '#f2f8e7'
+      beige: '#f2f8e7',
+      // These are from official ARA style guide. When doing new work, check if you can use these
+      'ara-2021-green': '#94c43a', // Ara basic green color. Not necessarily accessible
+      'ara-2021-green-background': '#e5efcd', // Basic background green when not using white
+      'ara-2021-green-large-text': '#79a130', // Accessible when used for large texts 18pt, 14pt bold
+      'ara-2021-green-small-text': '#59771e', // Accessible even with smaller text. Can be used as colored background for small white text
+      'ara-2021-light-gray-background': '#f1f1f1', // One of the basic background colors
+      'ara-2021-basic-gray': '#686767', // Basic gray color. Accessible when paired with white. Same as the disabled color
     },
     extend: {
       fontFamily: {


### PR DESCRIPTION
The colours in tailwind config aren't the official styleguide colors, as
the site pre-dates the styleguide. Added some of the official colors to
the configuration.

Background color was not set for the whole page. Footer had one gray
shade, while the rest of the page was transparent and thus used the
system default, which incidentally was the same shade as footer at least
for me. Explicitly set the background color for the whole application to
be the official gray shade. It differs slightly from the color used
elsewhere in the site, but not enought to be noticable at least by me.

Links in the footer did not have enough contrast. Added an option to
the Link component to add additional classes, and switched the footer
links to use the darker green meant for small text on non-white
background.

Change history-page in user history had a column for public information.
Public information was in bold green, whilst, non-public information was
in light grey, which didn't have enough contrast on gray rows. Changed the
column to show only the public fields in the same style as all other
information in the table.