### PR TITLE
AE-1974: Remove type-specific-data field from toimenpide data when updating käytönvalvonta toimenpide

### DIFF
--- a/src/pages/valvonta-kaytto/valvonta-api.js
+++ b/src/pages/valvonta-kaytto/valvonta-api.js
@@ -282,6 +282,7 @@ export const putToimenpide = R.curry((id, toimenpideId, toimenpide) =>
     Future.encaseP(
       Fetch.fetchWithMethod(fetch, 'put', url.toimenpide(id, toimenpideId))
     ),
+    R.dissoc('type-specific-data'),
     R.dissoc('type-id'),
     serializeToimenpide
   )(toimenpide)


### PR DESCRIPTION
- Its contents cannot be updated in the ui and backend api only takes fields that are needed
- Fixes bug that updating deadline date failed