### PR TITLE
AE-1960: Implement sakkopäätös / kuulemiskirje toimenpidetype with de…

### DIFF
--- a/src/language/fi.json
+++ b/src/language/fi.json
@@ -1962,6 +1962,13 @@
           "description": "Kommentti",
           "publish-button": "Luo toimenpide"
         },
+        "penalty-decision-hearing-letter": {
+          "title": "Sakkopäätös / kuulemiskirje",
+          "info": "Rakennuksen omistajilla on viimeinen mahdollisuus perustella, miksi energiatodistusta ei ole hankittu.",
+          "description": "Kommentti",
+          "fine": "Sakon suuruus €",
+          "publish-button": "Luo toimenpide"
+        },
         "messages": {
           "not-found": "Toimenpidettä ei ole olemassa.",
           "load-error": "Toimenpiteen tietojen haku epäonnistui.",

--- a/src/language/sv.json
+++ b/src/language/sv.json
@@ -1946,6 +1946,13 @@
           "description": "Kommentti (sv)",
           "publish-button": "Luo toimenpide (sv)"
         },
+        "penalty-decision-hearing-letter": {
+          "title": "Sakkopäätös / kuulemiskirje (sv)",
+          "info": "Rakennuksen omistajilla on viimeinen mahdollisuus perustella, miksi energiatodistusta ei ole hankittu. (sv)",
+          "description": "Kommentti (sv)",
+          "fine": "Sakon suuruus € (sv)",
+          "publish-button": "Luo toimenpide (sv)"
+        },
         "court-hearing": {
           "title": "HaO-käsittely (sv)",
           "info": "Rakennuksen omistaja on valittanut päätöksestä hallinto-oikeuteen ja HaO käsittelee valituksen. (sv)",

--- a/src/pages/valvonta-kaytto/manager.svelte
+++ b/src/pages/valvonta-kaytto/manager.svelte
@@ -47,7 +47,7 @@
       Toimenpiteet.emptyToimenpide(
         type,
         templatesByType,
-        Toimenpiteet.isActualDecision({ 'type-id': type })
+        Toimenpiteet.isDecisionOrderActualDecision({ 'type-id': type })
           ? {
               fine: Toimenpiteet.findFineFromToimenpiteet(toimenpiteet),
               departmentHeadName: johtaja['department-head-name'],

--- a/src/pages/valvonta-kaytto/manager.svelte
+++ b/src/pages/valvonta-kaytto/manager.svelte
@@ -61,9 +61,7 @@
           R.filter(Osapuolet.isOmistaja, R.concat(henkilot, yritykset))
         )
       };
-    }
-
-    if (
+    } else if (
       Toimenpiteet.isPenaltyDecisionHearingLetter({
         'type-id': toimenpideTypeId
       })

--- a/src/pages/valvonta-kaytto/manager.svelte
+++ b/src/pages/valvonta-kaytto/manager.svelte
@@ -49,7 +49,10 @@
         templatesByType,
         Toimenpiteet.isDecisionOrderActualDecision({ 'type-id': type })
           ? {
-              fine: Toimenpiteet.findFineFromToimenpiteet(toimenpiteet),
+              fine: Toimenpiteet.findFineFromToimenpiteet(
+                Toimenpiteet.isDecisionOrderHearingLetter,
+                toimenpiteet
+              ),
               departmentHeadName: johtaja['department-head-name'],
               departmentHeadTitleFi: johtaja['department-head-title-fi'],
               departmentHeadTitleSv: johtaja['department-head-title-sv'],

--- a/src/pages/valvonta-kaytto/manager.svelte
+++ b/src/pages/valvonta-kaytto/manager.svelte
@@ -42,26 +42,49 @@
 
   let toimenpideTyyppi = Maybe.None();
 
+  const toimenpideTypeSpecificDefaultValues = toimenpideTypeId => {
+    if (
+      Toimenpiteet.isDecisionOrderActualDecision({
+        'type-id': toimenpideTypeId
+      })
+    ) {
+      return {
+        fine: Toimenpiteet.findFineFromToimenpiteet(
+          Toimenpiteet.isDecisionOrderHearingLetter,
+          toimenpiteet
+        ),
+        departmentHeadName: johtaja['department-head-name'],
+        departmentHeadTitleFi: johtaja['department-head-title-fi'],
+        departmentHeadTitleSv: johtaja['department-head-title-sv'],
+        osapuoliIds: R.map(
+          R.prop('id'),
+          R.filter(Osapuolet.isOmistaja, R.concat(henkilot, yritykset))
+        )
+      };
+    }
+
+    if (
+      Toimenpiteet.isPenaltyDecisionHearingLetter({
+        'type-id': toimenpideTypeId
+      })
+    ) {
+      return {
+        fine: Toimenpiteet.findFineFromToimenpiteet(
+          Toimenpiteet.isDecisionOrderActualDecision,
+          toimenpiteet
+        )
+      };
+    }
+
+    return undefined;
+  };
+
   const openNewToimenpide = type => {
     newToimenpide = Maybe.Some(
       Toimenpiteet.emptyToimenpide(
         type,
         templatesByType,
-        Toimenpiteet.isDecisionOrderActualDecision({ 'type-id': type })
-          ? {
-              fine: Toimenpiteet.findFineFromToimenpiteet(
-                Toimenpiteet.isDecisionOrderHearingLetter,
-                toimenpiteet
-              ),
-              departmentHeadName: johtaja['department-head-name'],
-              departmentHeadTitleFi: johtaja['department-head-title-fi'],
-              departmentHeadTitleSv: johtaja['department-head-title-sv'],
-              osapuoliIds: R.map(
-                R.prop('id'),
-                R.filter(Osapuolet.isOmistaja, R.concat(henkilot, yritykset))
-              )
-            }
-          : undefined
+        toimenpideTypeSpecificDefaultValues(type)
       )
     );
   };

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -48,7 +48,6 @@
 
   let form;
   let error = Maybe.None();
-  let osapuolet = R.concat(henkilot, yritykset);
   let publishPending = false;
   let previewPending = false;
 

--- a/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -221,7 +221,7 @@
     </div>
   {/if}
 
-  {#if Toimenpiteet.isActualDecision(toimenpide)}
+  {#if Toimenpiteet.isDecisionOrderActualDecision(toimenpide)}
     <ActualDecisionSubView
       bind:toimenpide
       {i18n}
@@ -232,7 +232,7 @@
 
   {#if !R.isEmpty(templates)}
     <div class="mt-2">
-      {#if Toimenpiteet.isActualDecision(toimenpide)}
+      {#if Toimenpiteet.isDecisionOrderActualDecision(toimenpide)}
         <ActualDecisionOsapuoletTable
           {id}
           bind:toimenpide

--- a/src/pages/valvonta-kaytto/schema.js
+++ b/src/pages/valvonta-kaytto/schema.js
@@ -94,35 +94,37 @@ export const toimenpidePublish = (templates, toimenpide) =>
       'template-id': addRequiredValidator(!R.isEmpty(templates)),
       'type-specific-data': {
         'answer-commentary-fi': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         'answer-commentary-sv': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         'statement-fi': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         'statement-sv': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         fine: addRequiredValidator(Toimenpiteet.hasFine(toimenpide)),
         'osapuoli-specific-data': osapuoliSpecificSchema => {
           return R.map(
             R.over(
               R.lensProp('hallinto-oikeus-id'),
-              addRequiredValidator(Toimenpiteet.isActualDecision(toimenpide))
+              addRequiredValidator(
+                Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
+              )
             ),
             osapuoliSpecificSchema
           );
         },
         'department-head-title-fi': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         'department-head-title-sv': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         'department-head-name': addRequiredValidator(
-          Toimenpiteet.isActualDecision(toimenpide)
+          Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         )
       }
     },

--- a/src/pages/valvonta-kaytto/schema.js
+++ b/src/pages/valvonta-kaytto/schema.js
@@ -106,17 +106,26 @@ export const toimenpidePublish = (templates, toimenpide) =>
           Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),
         fine: addRequiredValidator(Toimenpiteet.hasFine(toimenpide)),
-        'osapuoli-specific-data': osapuoliSpecificSchema => {
-          return R.map(
-            R.over(
+        'osapuoli-specific-data': osapuoliSpecificSchema =>
+          R.addIndex(R.map)((item, index) => {
+            const hasDocument = R.path(
+              [
+                'type-specific-data',
+                'osapuoli-specific-data',
+                index,
+                'document'
+              ],
+              toimenpide
+            );
+            return R.over(
               R.lensProp('hallinto-oikeus-id'),
               addRequiredValidator(
-                Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
-              )
-            ),
-            osapuoliSpecificSchema
-          );
-        },
+                Toimenpiteet.isDecisionOrderActualDecision(toimenpide) &&
+                  hasDocument
+              ),
+              item
+            );
+          }, R.map(R.always(osapuoliSpecificSchema[0]), R.range(0, R.length(R.path(['type-specific-data', 'osapuoli-specific-data'], toimenpide))))),
         'department-head-title-fi': addRequiredValidator(
           Toimenpiteet.isDecisionOrderActualDecision(toimenpide)
         ),

--- a/src/pages/valvonta-kaytto/toimenpide.svelte
+++ b/src/pages/valvonta-kaytto/toimenpide.svelte
@@ -54,7 +54,7 @@
 
   {#if !Toimenpiteet.isDraft(toimenpide) && Toimenpiteet.hasTemplate(toimenpide)}
     {#each toimenpide.henkilot as henkilo}
-      {#if Toimenpiteet.isActualDecision(toimenpide) && !Toimenpiteet.documentExistsForOsapuoli(toimenpide, henkilo.id)}
+      {#if Toimenpiteet.isDecisionOrderActualDecision(toimenpide) && !Toimenpiteet.documentExistsForOsapuoli(toimenpide, henkilo.id)}
         <div>
           {henkilo.etunimi}
           {henkilo.sukunimi}
@@ -76,7 +76,7 @@
       {/if}
     {/each}
     {#each toimenpide.yritykset as yritys}
-      {#if Toimenpiteet.isActualDecision(toimenpide) && !Toimenpiteet.documentExistsForOsapuoli(toimenpide, yritys.id)}
+      {#if Toimenpiteet.isDecisionOrderActualDecision(toimenpide) && !Toimenpiteet.documentExistsForOsapuoli(toimenpide, yritys.id)}
         <div>
           {yritys.nimi}
           {Maybe.orSome('', yritys.ytunnus)}

--- a/src/pages/valvonta-kaytto/toimenpiteet.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet.js
@@ -201,6 +201,10 @@ export const isDecisionOrderHearingLetter = isType(
   R.path(['decision-order', 'hearing-letter'], type)
 );
 
+export const isPenaltyDecisionHearingLetter = isType(
+  R.path(['penalty-decision', 'hearing-letter'], type)
+);
+
 /**
  * Given an array of toimenpide objects, returns the fine found using the toimenpidetype predicate function parameter
  * @param {Function} toimenpidetypePredicate

--- a/src/pages/valvonta-kaytto/toimenpiteet.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet.js
@@ -193,11 +193,11 @@ export const toimenpideTypesThatAllowComments =
 export const hasFine = toimenpide =>
   R.hasPath(['type-specific-data', 'fine'], toimenpide);
 
-export const isActualDecision = isType(
+export const isDecisionOrderActualDecision = isType(
   R.path(['decision-order', 'actual-decision'], type)
 );
 
-const isHearingLetter = isType(
+const isDecisionOrderHearingLetter = isType(
   R.path(['decision-order', 'hearing-letter'], type)
 );
 
@@ -212,7 +212,7 @@ export const findFineFromToimenpiteet = R.compose(
   R.sort((a, b) =>
     dfns.compareDesc(R.prop('create-time', a), R.prop('create-time', b))
   ),
-  R.filter(isHearingLetter)
+  R.filter(isDecisionOrderHearingLetter)
 );
 
 /**

--- a/src/pages/valvonta-kaytto/toimenpiteet.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet.js
@@ -197,12 +197,13 @@ export const isDecisionOrderActualDecision = isType(
   R.path(['decision-order', 'actual-decision'], type)
 );
 
-const isDecisionOrderHearingLetter = isType(
+export const isDecisionOrderHearingLetter = isType(
   R.path(['decision-order', 'hearing-letter'], type)
 );
 
 /**
- * Given an array of toimenpide objects, returns the fine found in the newest toimenpide of type 7 (käskypäätös / kuulemiskirje)
+ * Given an array of toimenpide objects, returns the fine found using the toimenpidetype predicate function parameter
+ * @param {Function} toimenpidetypePredicate
  * @param {Object[]} toimenpiteet
  * @return {number}
  */
@@ -212,7 +213,7 @@ export const findFineFromToimenpiteet = R.compose(
   R.sort((a, b) =>
     dfns.compareDesc(R.prop('create-time', a), R.prop('create-time', b))
   ),
-  R.filter(isDecisionOrderHearingLetter)
+  R.filter
 );
 
 /**

--- a/src/pages/valvonta-kaytto/toimenpiteet.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet.js
@@ -23,6 +23,9 @@ export const type = {
     'actual-decision': 8,
     'notice-first-mailing': 9,
     'notice-second-mailing': 10
+  },
+  'penalty-decision': {
+    'hearing-letter': 14
   }
 };
 
@@ -32,7 +35,7 @@ export const typeKey = id => types[id];
 
 export const isType = R.propEq('type-id');
 
-const isDeadlineType = R.includes(R.__, [1, 2, 3, 4, 6, 7, 8, 9, 10]);
+const isDeadlineType = R.includes(R.__, [1, 2, 3, 4, 6, 7, 8, 9, 10, 14]);
 export const hasDeadline = R.propSatisfies(isDeadlineType, 'type-id');
 
 export const isCloseCase = isType(type.closed);
@@ -45,6 +48,7 @@ export const isAuditCaseToimenpideType = R.propSatisfies(
 const defaultDeadlineForTypeId = typeId => {
   switch (typeId) {
     case R.path(['decision-order', 'hearing-letter'], type):
+    case R.path(['penalty-decision', 'hearing-letter'], type):
       return Maybe.Some(dfns.addWeeks(new Date(), 2));
     case R.path(['decision-order', 'actual-decision'], type):
     case R.path(['decision-order', 'notice-first-mailing'], type):
@@ -93,6 +97,7 @@ export const emptyToimenpide = (
 
   switch (typeId) {
     case R.path(['decision-order', 'hearing-letter'], type):
+    case R.path(['penalty-decision', 'hearing-letter'], type):
       return R.assocPath(
         ['type-specific-data', 'fine'],
         Maybe.Some(fine),

--- a/src/pages/valvonta-kaytto/toimenpiteet_test.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet_test.js
@@ -68,8 +68,12 @@ describe('Toimenpiteet: ', () => {
     });
 
     it('is recognized correctly with isActualDecision function', () => {
-      assert.isTrue(Toimenpiteet.isActualDecision({ 'type-id': 8 }));
-      assert.isFalse(Toimenpiteet.isActualDecision({ 'type-id': 7 }));
+      assert.isTrue(
+        Toimenpiteet.isDecisionOrderActualDecision({ 'type-id': 8 })
+      );
+      assert.isFalse(
+        Toimenpiteet.isDecisionOrderActualDecision({ 'type-id': 7 })
+      );
     });
   });
 

--- a/src/pages/valvonta-kaytto/toimenpiteet_test.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet_test.js
@@ -299,7 +299,10 @@ describe('Empty toimenpide', () => {
   it('of type 8 has a default fine of 800 when toimenpiteet does not contain a previous fine', () => {
     const toimenpiteet = [];
     const emptyToimenpide = Toimenpiteet.emptyToimenpide(8, [], {
-      fine: Toimenpiteet.findFineFromToimenpiteet(toimenpiteet)
+      fine: Toimenpiteet.findFineFromToimenpiteet(
+        Toimenpiteet.isDecisionOrderHearingLetter,
+        toimenpiteet
+      )
     });
     assert.equal(
       800,
@@ -331,7 +334,13 @@ describe('findFineFromToimenpiteet returns the fine present in the newest toimen
       }
     ]);
 
-    assert.equal(Toimenpiteet.findFineFromToimenpiteet(toimenpiteet), 1000);
+    assert.equal(
+      Toimenpiteet.findFineFromToimenpiteet(
+        Toimenpiteet.isDecisionOrderHearingLetter,
+        toimenpiteet
+      ),
+      1000
+    );
   });
 
   it('when there are other toimenpiteet also present', () => {
@@ -348,7 +357,13 @@ describe('findFineFromToimenpiteet returns the fine present in the newest toimen
       }
     ]);
 
-    assert.equal(Toimenpiteet.findFineFromToimenpiteet(toimenpiteet), 2000);
+    assert.equal(
+      Toimenpiteet.findFineFromToimenpiteet(
+        Toimenpiteet.isDecisionOrderHearingLetter,
+        toimenpiteet
+      ),
+      2000
+    );
   });
 
   it('when there are multiple toimenpiteet of type 7', () => {
@@ -386,7 +401,13 @@ describe('findFineFromToimenpiteet returns the fine present in the newest toimen
       }
     ]);
 
-    assert.equal(Toimenpiteet.findFineFromToimenpiteet(toimenpiteet), 3000);
+    assert.equal(
+      Toimenpiteet.findFineFromToimenpiteet(
+        Toimenpiteet.isDecisionOrderHearingLetter,
+        toimenpiteet
+      ),
+      3000
+    );
   });
 });
 

--- a/src/pages/valvonta-kaytto/toimenpiteet_test.js
+++ b/src/pages/valvonta-kaytto/toimenpiteet_test.js
@@ -37,6 +37,15 @@ describe('Toimenpiteet: ', () => {
         );
       });
     });
+
+    it('is by default two weeks for type 14', () => {
+      assert.isTrue(
+        dfns.isSameDay(
+          dfns.addWeeks(new Date(), 2),
+          Maybe.get(Toimenpiteet.defaultDeadline(14))
+        )
+      );
+    });
   });
 
   describe('Käskypäätös / Kuulemiskirje', () => {
@@ -69,6 +78,16 @@ describe('Toimenpiteet: ', () => {
     assert.isFalse(
       Toimenpiteet.isToimenpideOfGivenTypes([7])({ 'type-id': 1 })
     );
+  });
+});
+
+describe('Sakkopäätös / Kuulemiskirje', () => {
+  it('id is mapped correctly to the type key', () => {
+    assert.equal('penalty-decision-hearing-letter', Toimenpiteet.typeKey(14));
+  });
+
+  it('is a type with a deadline', () => {
+    assert.isTrue(Toimenpiteet.hasDeadline({ 'type-id': 14 }));
   });
 });
 
@@ -168,6 +187,22 @@ describe('Empty toimenpide', () => {
         }
       ]
     );
+  });
+
+  it('Contains correct keys for toimenpidetype 14 which includes fine under type-specific-data', () => {
+    const emptyToimenpide = Toimenpiteet.emptyToimenpide(14, [{}]);
+    assert.deepEqual(Object.keys(emptyToimenpide), [
+      'type-id',
+      'publish-time',
+      'deadline-date',
+      'template-id',
+      'description',
+      'type-specific-data'
+    ]);
+
+    assert.deepEqual(Object.keys(emptyToimenpide['type-specific-data']), [
+      'fine'
+    ]);
   });
 
   it('with a fine is recognized as having a fine', () => {

--- a/src/pages/valvonta-kaytto/valvonta-api.js
+++ b/src/pages/valvonta-kaytto/valvonta-api.js
@@ -294,9 +294,8 @@ export const putToimenpide = R.curry((id, toimenpideId, toimenpide) =>
     Future.encaseP(
       Fetch.fetchWithMethod(fetch, 'put', url.toimenpide(id, toimenpideId))
     ),
-    R.dissoc('type-specific-data'),
-    R.dissoc('type-id'),
-    serializeToimenpide
+    serializeToimenpide,
+    R.omit(['type-specific-data', 'type-id']),
   )(toimenpide)
 );
 

--- a/src/pages/valvonta-kaytto/valvonta-api.js
+++ b/src/pages/valvonta-kaytto/valvonta-api.js
@@ -295,7 +295,7 @@ export const putToimenpide = R.curry((id, toimenpideId, toimenpide) =>
       Fetch.fetchWithMethod(fetch, 'put', url.toimenpide(id, toimenpideId))
     ),
     serializeToimenpide,
-    R.omit(['type-specific-data', 'type-id']),
+    R.omit(['type-specific-data', 'type-id'])
   )(toimenpide)
 );
 


### PR DESCRIPTION
Implement the new toimenpidetype with deadline, commenting and fine input. Fine prefilled with the fine from käskypäätös / varsinainen päätös.

Also bug fix for updating the deadline of these new toimenpide type toimenpides and fix for the schema of käskypäätös / varsinainen päätös to allow hallinto-oikeus-id to be empty if osapuoli has no document.